### PR TITLE
CLI run: fix panic on poll retry

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -142,6 +142,8 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 						}
 						time.Sleep(1 * time.Second)
 						continue
+					} else if res == nil {
+						continue
 					}
 
 					atomic.AddInt64(&successfulPolls, +1)


### PR DESCRIPTION
This fixes a bug introduced in #9. We need to retry when the poll response is nil.