### PR TITLE
expose the local endpoint to the application as the DISPATCH_ENDPOINT_ADDR environment variable

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -54,7 +54,9 @@ calls to it continuously.
 
 Dispatch connects to the local application on http://%s.
 If the local application is listening on a different host or port,
-please set the --endpoint option appropriately.
+please set the --endpoint option appropriately. The value passed to
+this option will be exported as the DISPATCH_ENDPOINT_ADDR environment
+variable to the local application.
 
 A new session is created each time the command is run. A session is
 a pristine environment in which function calls can be dispatched and
@@ -88,6 +90,7 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 				os.Environ(),
 				"DISPATCH_API_KEY="+DispatchApiKey,
 				"DISPATCH_ENDPOINT_URL=bridge://"+BridgeSession,
+				"DISPATCH_ENDPOINT_ADDR="+LocalEndpoint,
 			)
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cli/run.go
+++ b/cli/run.go
@@ -26,7 +26,7 @@ var (
 	LocalEndpoint string
 )
 
-const defaultEndpoint = "localhost:8000"
+const defaultEndpoint = "[::]:8000"
 
 const (
 	pollTimeout    = 30 * time.Second


### PR DESCRIPTION
The intent of this change is to allow the Dispatch SDK to automatically discover the local endpoint that the CLI will be connecting to.