### PR TITLE
Unset DISPATCH_VERIFICATION_KEY before running local application

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -11,10 +11,9 @@ import (
 )
 
 var (
-	DispatchApiKey          string
-	DispatchApiKeyCli       string
-	DispatchApiKeyLocation  string
-	DispatchVerificationKey string
+	DispatchApiKey         string
+	DispatchApiKeyCli      string
+	DispatchApiKeyLocation string
 
 	DispatchApiUrl           string
 	DispatchBridgeUrl        string
@@ -36,10 +35,6 @@ func init() {
 		DispatchBridgeUrl = "https://bridge.dispatch.run"
 	}
 	DispatchBridgeHostHeader = os.Getenv("DISPATCH_BRIDGE_HOST_HEADER")
-
-	if key := os.Getenv("DISPATCH_VERIFICATION_KEY"); key != "" {
-		DispatchVerificationKey = key
-	}
 
 	DispatchConsoleUrl = os.Getenv("DISPATCH_CONSOLE_URL")
 	if DispatchConsoleUrl == "" {

--- a/cli/run.go
+++ b/cli/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -329,18 +330,12 @@ func cleanup(ctx context.Context, client *http.Client, url, requestID string) er
 }
 
 func withoutEnv(env []string, prefixes ...string) []string {
-	result := make([]string, 0, len(env))
-	for _, v := range env {
-		ok := true
+	return slices.DeleteFunc(env, func(v string) bool {
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(v, prefix) {
-				ok = false
-				break
+				return true
 			}
 		}
-		if ok {
-			result = append(result, v)
-		}
-	}
-	return result
+		return false
+	})
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -85,14 +85,15 @@ Run 'dispatch help run' to learn about Dispatch sessions.`, BridgeSession)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 
-			// Pass on environment variables to the local application.
-			// Pass on the configured API key, and set a special endpoint
-			// URL for the session. Unset the verification key, so that
-			// it doesn't conflict with the session. A verification key
-			// is not required here, since function calls are retrieved
-			// from an authenticated API endpoint.
+			// Pass on environment variables to the local application. Pass on the
+			// configured API key, and set a special endpoint URL for the session.
+			// Unset all DISPATCH_* environment variables, which includes overrides for
+			// the CLI and also the verification key (DISPATCH_VERIFICATION_KEY), so
+			// that they don't conflict with the session. Note that a verification key
+			// is not required here, since function calls are retrieved from an
+			// authenticated API endpoint.
 			cmd.Env = append(
-				withoutEnv(os.Environ(), "DISPATCH_VERIFICATION_KEY="),
+				withoutEnv(os.Environ(), "DISPATCH_"),
 				"DISPATCH_API_KEY="+DispatchApiKey,
 				"DISPATCH_ENDPOINT_URL=bridge://"+BridgeSession,
 			)


### PR DESCRIPTION
The Dispatch SDK accepts three environment variables: https://github.com/stealthrocket/dispatch-py?tab=readme-ov-file#configuration.

The `dispatch run` command sets (overrides) two of them, `DISPATCH_API_KEY` and `DISPATCH_ENDPOINT_URL`, but passes on the third (`DISPATCH_VERIFICATION_KEY`) from the environment. A verification key is not required when using `dispatch run` because function calls are pulled from an authenticated endpoint of the Dispatch API.

This PR unsets `DISPATCH_VERIFICATION_KEY` before starting the local application, so that it doesn't conflict with the `dispatch run` session.

cc #8