### PR TITLE
Do not read DISPATCH_API_KEY

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -111,11 +111,6 @@ func runConfigFlow() error {
 		}
 	}
 
-	if key := os.Getenv("DISPATCH_API_KEY"); key != "" {
-		DispatchApiKey = key
-		DispatchApiKeyLocation = "env"
-	}
-
 	if key := DispatchApiKeyCli; key != "" {
 		DispatchApiKey = key
 		DispatchApiKeyLocation = "cli"
@@ -125,7 +120,7 @@ func runConfigFlow() error {
 		if len(config) > 0 {
 			return fmt.Errorf("No organization selected. Please run `dispatch switch` to select one.")
 		}
-		return fmt.Errorf("Please run `dispatch login` to login to Dispatch. Alternatively, set the DISPATCH_API_KEY environment variable, or provide an --api-key (-k) on the command line.")
+		return fmt.Errorf("Please run `dispatch login` to login to Dispatch. Alternatively, provide an --api-key (-k) on the command line.")
 	}
 	return nil
 }

--- a/cli/error.go
+++ b/cli/error.go
@@ -8,8 +8,6 @@ func (authError) Error() string {
 	const message = "Authentication error when contacting the Dispatch API"
 	var detail string
 	switch DispatchApiKeyLocation {
-	case "env":
-		detail = "check DISPATCH_API_KEY environment variable"
 	case "cli":
 		detail = "check the -k,--api-key command-line option"
 	default:

--- a/cli/main.go
+++ b/cli/main.go
@@ -23,7 +23,7 @@ Support: support@dispatch.run
 			return cmd.Help()
 		},
 	}
-	cmd.PersistentFlags().StringVarP(&DispatchApiKeyCli, "api-key", "k", "", "Dispatch API key (env: DISPATCH_API_KEY)")
+	cmd.PersistentFlags().StringVarP(&DispatchApiKeyCli, "api-key", "k", "", "Dispatch API key override")
 
 	cmd.AddGroup(&cobra.Group{
 		ID:    "management",


### PR DESCRIPTION
We no longer accept an API key via `DISPATCH_API_KEY`, since it overrides the local configuration and makes it too easy to use the wrong key.

The API key is read from the local YAML configuration (populated by `dispatch login`). An override can still be provided to all commands via `-k,--api-key`. If the user really wants to use the value of the `DISPATCH_API_KEY` environment variable, they can explicitly opt-in by invoking `dispatch` with `--api-key $DISPATCH_API_KEY`.

Note that `dispatch run` sets/overrides the value of `DISPATCH_API_KEY` before spawning the local application. There's no need to strip the value from the environment, though we could perhaps print a warning if it's set to something other than the value found in local configuration or the one passed to `-k,--api-key` ?

cc #8.