### PR TITLE
Respect XDG_CONFIG_HOME for configuration file

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 
@@ -61,7 +60,7 @@ If the browser does not open, please visit the following URL:
 				success("Authentication successful")
 				fmt.Printf(
 					"Configuration file created at %s\n",
-					os.ExpandEnv("$HOME/.dispatch.toml"),
+					DispatchConfigPath,
 				)
 			}
 			return nil


### PR DESCRIPTION
This PR updates the CLI to store its configuration in `$XDG_CONFIG_HOME/dispatch/config.toml`, according to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). If `XDG_CONFIG_HOME` is not set, it defaults to `$HOME/.config`

For most users, this means that configuration will be stored at `$HOME/.config/dispatch/config.toml`

The `DISPATCH_CONFIG_PATH` override is still available, and takes precedence if set.