### PR TITLE
Rework the configuration file

### DIFF
--- a/cli/console.go
+++ b/cli/console.go
@@ -52,13 +52,18 @@ func (c *console) Login(token string) error {
 		break
 	}
 
-	config := make(Config)
+	var config Config
+	config.Warning = "THIS FILE IS GENERATED. DO NOT EDIT!"
+	config.Organization = map[string]Organization{}
 
 	for i, org := range clilogin.Organizations {
-		config[org.Slug] = Keys{ApiKey: org.ApiKey, Active: i == 0}
+		config.Organization[org.Slug] = Organization{APIKey: org.ApiKey}
+		if i == 0 {
+			config.Active = org.Slug
+		}
 	}
 
-	if err := CreateConfig(DispatchConfigPath, config); err != nil {
+	if err := CreateConfig(DispatchConfigPath, &config); err != nil {
 		return fmt.Errorf("failed to create config: %w", err)
 	}
 	return nil

--- a/cli/switch.go
+++ b/cli/switch.go
@@ -32,7 +32,7 @@ To manage your organizations, visit the Dispatch Console: https://console.dispat
 			// List organizations if no arguments were provided.
 			if len(args) == 0 {
 				fmt.Println("Available organizations:")
-				for org := range cfg {
+				for org := range cfg.Organization {
 					fmt.Println("-", org)
 				}
 				return nil
@@ -40,28 +40,19 @@ To manage your organizations, visit the Dispatch Console: https://console.dispat
 
 			// Otherwise, try to switch to the specified organization.
 			name := args[0]
-			_, ok := cfg[name]
+			_, ok := cfg.Organization[name]
 			if !ok {
 				failure(fmt.Sprintf("Organization '%s' not found", name))
 
 				fmt.Println("Available organizations:")
-				for org := range cfg {
+				for org := range cfg.Organization {
 					fmt.Println("-", org)
 				}
 				return nil
 			}
 
 			simple(fmt.Sprintf("Switched to organization: %v", name))
-			for org, keys := range cfg {
-				if keys.Active && org != name {
-					keys.Active = false
-					cfg[org] = keys
-				}
-				if org == name {
-					keys.Active = true
-					cfg[org] = keys
-				}
-			}
+			cfg.Active = name
 			return CreateConfig(DispatchConfigPath, cfg)
 		},
 	}


### PR DESCRIPTION
This PR reworks the configuration file:
* we print a warning comment at the beginning of the file letting the user know that the file is generated, and that it should not be edited directly
* we prefix organization configuration so that we can have configuration scoped to the CLI
* we hoist the `active` field out of the organization scope

Here's an example:

```toml
# Warning = 'THIS FILE IS GENERATED. DO NOT EDIT!'
active = 'org1'

[Organizations]
[Organizations.org1]
api_key = 'foobar'

[Organizations.org2]
api_key = 'abcxyz'
```

It's not the prettiest looking thing, but this is what the TOML library we're using generates. I don't think we can improve it without using lower-level APIs or generating the file manually.

This fixes https://github.com/stealthrocket/dispatch/issues/5.