### PR TITLE
default to use ipv4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@
 *.so
 *.dylib
 /build
+/dispatch
 
 # Test binary, built with `go test -c`
 *.test
+*.py
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/cli/run.go
+++ b/cli/run.go
@@ -27,7 +27,7 @@ var (
 	LocalEndpoint string
 )
 
-const defaultEndpoint = "[::]:8000"
+const defaultEndpoint = "127.0.0.1:8000"
 
 const (
 	pollTimeout    = 30 * time.Second


### PR DESCRIPTION
There were some issues with Python's urllib and http.server modules when using IPv6.