### PR TITLE
run: buffer line output

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -493,9 +493,9 @@ func printPrefixedLines(w io.Writer, r io.Reader, prefix, suffix []byte) {
 
 	for scanner.Scan() {
 		buffer.Truncate(len(prefix))
-		_, _ = buffer.Write(scanner.Bytes())
-		_, _ = buffer.Write(suffix)
-		w.Write(buffer.Bytes())
+		buffer.Write(scanner.Bytes())
+		buffer.Write(suffix)
+		_, _ = w.Write(buffer.Bytes())
 	}
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -488,10 +488,14 @@ func (h *prefixHandler) Handle(ctx context.Context, r slog.Record) error {
 
 func printPrefixedLines(w io.Writer, r io.Reader, prefix, suffix []byte) {
 	scanner := bufio.NewScanner(r)
+	buffer := bytes.NewBuffer(nil)
+	buffer.Write(prefix)
+
 	for scanner.Scan() {
-		_, _ = w.Write(prefix)
-		_, _ = w.Write(scanner.Bytes())
-		_, _ = w.Write(suffix)
+		buffer.Truncate(len(prefix))
+		_, _ = buffer.Write(scanner.Bytes())
+		_, _ = buffer.Write(suffix)
+		w.Write(buffer.Bytes())
 	}
 }
 


### PR DESCRIPTION
A minor improvement to avoid interleaving due to unbuffered writes to `os.Stderr`.