### PR TITLE
Create CLI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ goreleaser/
 .netrc
 
 .dispatch
+
+docs/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 project_name: dispatch
 dist: ./goreleaser/dist
+version: 2
 
 before:
   hooks:
@@ -9,7 +10,8 @@ gomod:
   proxy: true
 
 builds:
-  - main: .
+  - id: dispatch
+    main: .
     binary: dispatch
     mod_timestamp: "{{ .CommitTimestamp }}"
 
@@ -21,6 +23,25 @@ builds:
       - darwin
       - linux
       - windows
+
+  - id: dispatch-docs
+    main: .
+    binary: dispatch-docs
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    tags: docs
+
+    goarch:
+      - amd64
+
+    goos:
+      - linux
+
+archives:
+  - id: dispatch
+    builds: [dispatch]
+  - id: dispatch-docs
+    builds: [dispatch-docs]
+    name_template: "{{ .ProjectName }}_docs_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 release:
   github:
@@ -34,6 +55,8 @@ changelog:
 
 brews:
   - name: dispatch
+    ids:
+      - dispatch
     url_template: "https://github.com/dispatchrun/dispatch/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     commit_author:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,10 @@ builds:
 archives:
   - id: dispatch
     builds: [dispatch]
+    format_overrides:
+      - goos: windows
+        format: zip
+
   - id: dispatch-docs
     builds: [dispatch-docs]
     name_template: "{{ .ProjectName }}_docs_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ push: image
 update:
 	for ref in $$(yq -r '.deps[] | .remote + "/gen/go/" + .owner + "/" + .repository + "/protocolbuffers/go@" + .commit' proto/buf.lock); do go get $$ref; done
 	go mod tidy
+
+dispatch-docs:
+	${GO} build -tags docs -o ${DISPATCH} .
+	${DISPATCH}

--- a/cli/generate_docs.go
+++ b/cli/generate_docs.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path"
 	"strings"
@@ -13,37 +14,55 @@ import (
 
 var isDocsBuild = true
 
-func generateDocs(cmd *cobra.Command, filename string, title string) {
+func generateDocs(cmd *cobra.Command, title string) {
 	cmd.DisableAutoGenTag = true
 
 	// create docs directory
 	_ = os.Mkdir("./docs", 0755)
 
-	err := doc.GenMarkdownTreeCustom(cmd, "./docs",
-		func(_ string) string {
-			return `---
-title: ` + title + `
----
+	out := new(bytes.Buffer)
 
-`
-		},
-		func(name string) string {
-			// err := doc.GenMarkdownCustom(cmd, out, func(name string) string {
-			base := strings.TrimSuffix(name, path.Ext(name))
-			return "/cli/" + strings.ToLower(base) + "/"
-		})
+	err := doc.GenMarkdownCustom(cmd, out, func(name string) string {
+		// err := doc.GenMarkdownCustom(cmd, out, func(name string) string {
+		base := strings.TrimSuffix(name, path.Ext(name))
+		return "/cli/" + strings.ToLower(base) + "/"
+	})
 	if err != nil {
 		panic(err)
 	}
+
+	// Define the text to be replaced and the replacement text
+	oldText := []byte("## " + title)
+	newText := []byte("---\ntitle: " + title + "\n---")
+
+	// Perform the replacement on the buffer's content
+	updatedContent := bytes.Replace(out.Bytes(), oldText, newText, 1)
+
+	// Reset the buffer and write the updated content back to it
+	out.Reset()
+	out.Write(updatedContent)
+
+	// write markdown to file
+	file, err := os.Create("./docs/" + strings.ReplaceAll(title, " ", "_") + ".md")
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = file.Write(out.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	defer file.Close()
 
 	// if command has subcommands, generate markdown for each subcommand
 	if cmd.HasSubCommands() {
 		for _, c := range cmd.Commands() {
 			// if c.Use starts with "help", skip it
-			if strings.HasPrefix(c.Use, "help") {
+			if c.Name() == "help" {
 				continue
 			}
-			generateDocs(c, filename, title+" "+c.Use)
+			generateDocs(c, title+" "+c.Name())
 		}
 	}
 }

--- a/cli/generate_docs.go
+++ b/cli/generate_docs.go
@@ -12,7 +12,9 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-var isDocsBuild = true
+const DispatchCmdLong = "This is the main command for Dispatch CLI. Add a subcommand to make it useful."
+
+const RunExampleText = "```\ndispatch run [options] -- <command>\n```"
 
 func generateDocs(cmd *cobra.Command, title string) {
 	cmd.DisableAutoGenTag = true

--- a/cli/generate_docs.go
+++ b/cli/generate_docs.go
@@ -1,0 +1,49 @@
+//go:build docs
+
+package cli
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+var isDocsBuild = true
+
+func generateDocs(cmd *cobra.Command, filename string, title string) {
+	cmd.DisableAutoGenTag = true
+
+	// create docs directory
+	_ = os.Mkdir("./docs", 0755)
+
+	err := doc.GenMarkdownTreeCustom(cmd, "./docs",
+		func(_ string) string {
+			return `---
+title: ` + title + `
+---
+
+`
+		},
+		func(name string) string {
+			// err := doc.GenMarkdownCustom(cmd, out, func(name string) string {
+			base := strings.TrimSuffix(name, path.Ext(name))
+			return "/cli/" + strings.ToLower(base) + "/"
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// if command has subcommands, generate markdown for each subcommand
+	if cmd.HasSubCommands() {
+		for _, c := range cmd.Commands() {
+			// if c.Use starts with "help", skip it
+			if strings.HasPrefix(c.Use, "help") {
+				continue
+			}
+			generateDocs(c, filename, title+" "+c.Use)
+		}
+	}
+}

--- a/cli/generate_docs_default.go
+++ b/cli/generate_docs_default.go
@@ -6,6 +6,6 @@ import "github.com/spf13/cobra"
 
 var isDocsBuild = false
 
-func generateDocs(_ *cobra.Command, _ string, _ string) {
+func generateDocs(_ *cobra.Command, _ string) {
 	// do nothing if the build tag "docs" is not set
 }

--- a/cli/generate_docs_default.go
+++ b/cli/generate_docs_default.go
@@ -1,0 +1,11 @@
+//go:build !docs
+
+package cli
+
+import "github.com/spf13/cobra"
+
+var isDocsBuild = false
+
+func generateDocs(_ *cobra.Command, _ string, _ string) {
+	// do nothing if the build tag "docs" is not set
+}

--- a/cli/generate_docs_default.go
+++ b/cli/generate_docs_default.go
@@ -4,7 +4,16 @@ package cli
 
 import "github.com/spf13/cobra"
 
-var isDocsBuild = false
+const DispatchCmdLong = `Welcome to Dispatch!
+
+To get started, use the login command to authenticate with Dispatch or create an account.
+
+Documentation: https://docs.dispatch.run
+Discord: https://dispatch.run/discord
+Support: support@dispatch.run
+`
+
+const RunExampleText = "  dispatch run [options] -- <command>"
 
 func generateDocs(_ *cobra.Command, _ string) {
 	// do nothing if the build tag "docs" is not set

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,29 +6,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	DispatchCmdLong = `Welcome to Dispatch!
-
-To get started, use the login command to authenticate with Dispatch or create an account.
-
-Documentation: https://docs.dispatch.run
-Discord: https://dispatch.run/discord
-Support: support@dispatch.run
-`
-)
-
-var mainCommandText string
-
 func createMainCommand() *cobra.Command {
-	if isDocsBuild {
-		mainCommandText = "This is the main command for Dispatch CLI. Add a subcommand to make it useful."
-	} else {
-		mainCommandText = DispatchCmdLong
-	}
 	cmd := &cobra.Command{
 		Version: version(),
 		Use:     "dispatch",
-		Long:    mainCommandText,
+		Long:    DispatchCmdLong,
 		Short:   "Main command for Dispatch CLI",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return loadEnvFromFile(DotEnvFilePath)

--- a/cli/main.go
+++ b/cli/main.go
@@ -59,12 +59,7 @@ func createMainCommand() *cobra.Command {
 	cmd.AddCommand(versionCommand())
 
 	// Generate markdown documentation
-	generateDocs(loginCommand(), "dispatch_login.md", "dispatch login")
-	generateDocs(initCommand(), "dispatch_init.md", "dispatch init")
-	generateDocs(switchCommand(DispatchConfigPath), "dispatch_switch.md", "dispatch switch")
-	generateDocs(verificationCommand(), "dispatch_verification.md", "dispatch verification")
-	generateDocs(runCommand(), "dispatch_run.md", "dispatch run")
-	generateDocs(versionCommand(), "dispatch_version.md", "dispatch version")
+	generateDocs(cmd, "dispatch")
 
 	return cmd
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -17,11 +17,19 @@ Support: support@dispatch.run
 `
 )
 
+var mainCommandText string
+
 func createMainCommand() *cobra.Command {
+	if isDocsBuild {
+		mainCommandText = "This is the main command for Dispatch CLI. Add a subcommand to make it useful."
+	} else {
+		mainCommandText = DispatchCmdLong
+	}
 	cmd := &cobra.Command{
 		Version: version(),
 		Use:     "dispatch",
-		Long:    DispatchCmdLong,
+		Long:    mainCommandText,
+		Short:   "Main command for Dispatch CLI",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return loadEnvFromFile(DotEnvFilePath)
 		},
@@ -49,6 +57,14 @@ func createMainCommand() *cobra.Command {
 	cmd.AddCommand(verificationCommand())
 	cmd.AddCommand(runCommand())
 	cmd.AddCommand(versionCommand())
+
+	// Generate markdown documentation
+	generateDocs(loginCommand(), "dispatch_login.md", "dispatch login")
+	generateDocs(initCommand(), "dispatch_init.md", "dispatch init")
+	generateDocs(switchCommand(DispatchConfigPath), "dispatch_switch.md", "dispatch switch")
+	generateDocs(verificationCommand(), "dispatch_verification.md", "dispatch verification")
+	generateDocs(runCommand(), "dispatch_run.md", "dispatch run")
+	generateDocs(versionCommand(), "dispatch_version.md", "dispatch version")
 
 	return cmd
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -56,15 +56,7 @@ var (
 	logPrefixSeparatorStyle = lipgloss.NewStyle().Foreground(grayColor)
 )
 
-var runExampleText string
-
 func runCommand() *cobra.Command {
-	if isDocsBuild {
-		runExampleText = "```\ndispatch run [options] -- <command>\n```"
-	} else {
-		runExampleText = "  dispatch run [options] -- <command>"
-	}
-
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a Dispatch application",
@@ -73,7 +65,7 @@ func runCommand() *cobra.Command {
 The command to start the local application endpoint should be
 specified after the run command and its options:
 
-`+runExampleText+`
+`+RunExampleText+`
 
 Dispatch spawns the local application endpoint and then dispatches
 function calls to it continuously.

--- a/cli/run.go
+++ b/cli/run.go
@@ -56,7 +56,15 @@ var (
 	logPrefixSeparatorStyle = lipgloss.NewStyle().Foreground(grayColor)
 )
 
+var runExampleText string
+
 func runCommand() *cobra.Command {
+	if isDocsBuild {
+		runExampleText = "```\ndispatch run [options] -- <command>\n```"
+	} else {
+		runExampleText = "  dispatch run [options] -- <command>"
+	}
+
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a Dispatch application",
@@ -65,7 +73,7 @@ func runCommand() *cobra.Command {
 The command to start the local application endpoint should be
 specified after the run command and its options:
 
-  dispatch run [options] -- <command>
+`+runExampleText+`
 
 Dispatch spawns the local application endpoint and then dispatches
 function calls to it continuously.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/joho/godotenv v1.5.1
 	github.com/muesli/reflow v0.3.0
+	github.com/muesli/termenv v0.15.2
 	github.com/nlpodyssey/gopickle v0.3.0
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/spf13/cobra v1.8.0
@@ -31,7 +32,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.6 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -33,6 +34,7 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.6 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/charmbracelet/lipgloss v0.9.1 h1:PNyd3jvaJbg4jRHKWXnCj1akQm4rh8dbEzN1
 github.com/charmbracelet/lipgloss v0.9.1/go.mod h1:1mPmG4cxScwUQALAAnacHaigiiHB9Pmr+v1VEawJl6I=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -51,6 +52,7 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=
 github.com/rivo/uniseg v0.4.6/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=


### PR DESCRIPTION
This PR adds a new `dispatch-docs` rule to the Makefile. It builds CLI with a `docs` build flag.

Markdown is generated in the `./docs` directory with Cobra's built-in [markdown generator](https://github.com/spf13/cobra/blob/main/site/content/docgen/md.md). There's a special case where we have to wrap run command example in the usage by triple backticks to make it look properly in the markdown. ~~This is made possible by adding a `isDocsBuild` flag.~~
We can then add those docs to the developer website.